### PR TITLE
feat(eval): add option to disable automatic main function wrapper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1408,7 +1408,7 @@ dependencies = [
 
 [[package]]
 name = "rust-discord-bot"
-version = "0.5.4"
+version = "0.6.0"
 dependencies = [
  "chrono",
  "dotenv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-discord-bot"
-version = "0.5.4"
+version = "0.6.0"
 edition = "2024"
 
 [dependencies]


### PR DESCRIPTION
`eval`コマンドに main関数の自動生成を抑制するオプションを追加

  ## 主な変更点

### 変更

プロジェクトのバージョンを  0.5.4  から  0.6.0に
* src/commands/eval.rs

### 追加 (eval.rs):
* /eval  スラッシュコマンドに、 `no-main`というBoolean optionを追加
* 目的:
  * main(){}のような定型コードの自動補完を無効化できるように

### 修正 (Modified):

* `no-main`オプションの実装のため、ReqJson::new ,  FileContent::new ,  code_generator関数の引数を変更
* code_generator  関数のロジックを修正し、 no-main  オプションが  true
    の場合は、 main関数の自動補完をスキップ

* Go言語のコード生成テンプレートにて`package main`と`import "fmt"`を追加
* メソッド名を  get_gen_code  から  get_generated_code (可読性向上のため)