### PR TITLE
feat(eval): eval commandの結果を送信者にのみ表示するオプションを追加

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1408,7 +1408,7 @@ dependencies = [
 
 [[package]]
 name = "rust-discord-bot"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "chrono",
  "dotenv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-discord-bot"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 
 [dependencies]


### PR DESCRIPTION
* hide optionをtrueにすることでevalの結果を送信者にのみ表示するように
* no-main optionの名前をno-wrap-mainに

動作の様子

<img width="556" height="260" alt="Screenshot 2025-10-22 at 15 49 53" src="https://github.com/user-attachments/assets/49c700fb-da16-4f31-8d6c-282de17b0142" />
