### PR TITLE
feat: improve speech bubble rendering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1408,7 +1408,7 @@ dependencies = [
 
 [[package]]
 name = "rust-discord-bot"
-version = "0.8.0"
+version = "0.9.1"
 dependencies = [
  "chrono",
  "dotenv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-discord-bot"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2024"
 
 [dependencies]

--- a/src/commands/hukidashi.rs
+++ b/src/commands/hukidashi.rs
@@ -51,10 +51,8 @@ fn mul_str<T: AsRef<str> + Sized>(msg: &T, mul: u32) -> String {
 // ￣人人人人人人人￣
 fn s2huki<T: AsRef<str>>(s: T) -> String {
     let max_width = get_max_len(&s);
-    //                          discordのフォントによるが-2では表示が崩れる
-    let buns = mul_str(&"人", max_width - 4);
-    let top = format!("＿{}＿\n", &buns);
-    let btm = format!("￣{}￣\n", &buns);
+    let top = format!("＿{}＿\n", mul_str(&"人", max_width / 2));
+    let btm = format!("￣{}￣\n", mul_str(&"Y^", max_width / 2));
     let mut ss = String::new();
     ss.push_str(&top);
     for l in s.as_ref().lines() {


### PR DESCRIPTION
ちゃんと文字長に対応 & 装飾の改善

<img width="366" height="165" alt="Screenshot 2025-11-14 at 19 17 10" src="https://github.com/user-attachments/assets/bfe3cda4-d056-4065-9fa0-f4d6c6c8a2dc" />
